### PR TITLE
Make RCC enr() and rstr() public

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -45,7 +45,7 @@ pub struct AHB {
 }
 
 impl AHB {
-    pub(crate) fn enr(&mut self) -> &rcc::AHBENR {
+    pub fn enr(&mut self) -> &rcc::AHBENR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).ahbenr }
     }
@@ -57,12 +57,12 @@ pub struct APB1 {
 }
 
 impl APB1 {
-    pub(crate) fn enr(&mut self) -> &rcc::APB1ENR {
+    pub fn enr(&mut self) -> &rcc::APB1ENR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).apb1enr }
     }
 
-    pub(crate) fn rstr(&mut self) -> &rcc::APB1RSTR {
+    pub fn rstr(&mut self) -> &rcc::APB1RSTR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).apb1rstr }
     }
@@ -74,12 +74,12 @@ pub struct APB2 {
 }
 
 impl APB2 {
-    pub(crate) fn enr(&mut self) -> &rcc::APB2ENR {
+    pub fn enr(&mut self) -> &rcc::APB2ENR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).apb2enr }
     }
 
-    pub(crate) fn rstr(&mut self) -> &rcc::APB2RSTR {
+    pub fn rstr(&mut self) -> &rcc::APB2RSTR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).apb2rstr }
     }


### PR DESCRIPTION
Functions for enable, reset peripherals can be used in other crates or in main.