### PR TITLE
Make serial error flags reset after read

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -201,9 +201,9 @@ macro_rules! hal {
                         }
                         Err(nb::Error::Other(err))
                     } else {
+                        // Check if a byte is available
                         if sr.rxne().bit_is_set() {
-                            // Read the data register and return that error. This must be done
-                            // in order to clear the error bits
+                            // Read the received byte
                             // NOTE(read_volatile) see `write_volatile` below
                             Ok(unsafe {
                                 ptr::read_volatile(&(*$USARTX::ptr()).dr as *const _ as *const _)


### PR DESCRIPTION
If any error occurs during serial read, a flag is set in the USARTx_SR register. However, this flag is not currently reset after being read which means that any errors are permanent.

The flags are reset by a read from the `sr` register followed by a read from `dr` which is what this PR does.

This seems to work in my limted testing, but I am not sure why the `sr.<bit>().bit_is_set()` doesn't count as a read for this purpose.