### PR TITLE
Allow for delay longer than (1<<24) ticks

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -7,9 +7,6 @@ use cortex_m::peripheral::syst::SystClkSource;
 use hal::blocking::delay::{DelayMs, DelayUs};
 use rcc::Clocks;
 
-// The RVR register is 24 bits wide, as SysTick is based on a 24 bit counter
-const MAX_RVR: u32 = (1 << 24);
-
 /// System timer (SysTick) as a delay provider
 pub struct Delay {
     clocks: Clocks,
@@ -50,6 +47,9 @@ impl DelayMs<u8> for Delay {
 
 impl DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
+        // The RVR register is 24 bits wide, as SysTick is based on a 24 bit counter
+        const MAX_RVR: u32 = (1 << 24);
+        
         let mut total_rvr = us * (self.clocks.sysclk().0 / 1_000_000);
 
         while total_rvr != 0 {

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -47,17 +47,26 @@ impl DelayMs<u8> for Delay {
 
 impl DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
-        let rvr = us * (self.clocks.sysclk().0 / 1_000_000);
+        let mut rvr = us * (self.clocks.sysclk().0 / 1_000_000);
 
-        assert!(rvr < (1 << 24));
+        while rvr != 0 {
+            let rvr_inner = if rvr < (1 << 24) {
+                rvr
+            } else {
+                1 << 24
+            };
 
-        self.syst.set_reload(rvr);
-        self.syst.clear_current();
-        self.syst.enable_counter();
+            self.syst.set_reload(rvr);
+            self.syst.clear_current();
+            self.syst.enable_counter();
 
-        while !self.syst.has_wrapped() {}
+            // Update the tracking variable while we are waiting...
+            rvr -= rvr_inner;
 
-        self.syst.disable_counter();
+            while !self.syst.has_wrapped() {}
+
+            self.syst.disable_counter();
+        }
     }
 }
 


### PR DESCRIPTION
For higher frequency devices (such as the nRF52 at 64MHz), `1 << 24` ticks is only 250ms or so. Allow longer delays if necessary.