### PR TITLE
Adds features to specify stm32f103xx flash density

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,15 @@ version = "0.8.0"
 [features]
 doc = []
 rt = ["stm32f103xx/rt"]
+stm32f103x4 = []
+stm32f103x6 = []
+stm32f103x8 = []
+stm32f103xB = []
+stm32f103xC = []
+stm32f103xD = []
+stm32f103xE = []
+stm32f103xF = []
+stm32f103xG = []
 
 [profile.dev]
 incremental = false

--- a/build.rs
+++ b/build.rs
@@ -3,12 +3,75 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
+#[cfg(all(feature = "stm32f103x4", not(any(feature = "stm32f103x6", feature = "stm32f103x8", feature = "stm32f103xB", feature = "stm32f103xC", feature = "stm32f103xD", feature = "stm32f103xE", feature = "stm32f103xF", feature = "stm32f103xG"))))]
+macro_rules! memory_file {
+    () => {
+        include_bytes!("memory/stm32f103x4.x")
+    }
+}
+
+#[cfg(all(feature = "stm32f103x6", not(any(feature = "stm32f103x4", feature = "stm32f103x8", feature = "stm32f103xB", feature = "stm32f103xC", feature = "stm32f103xD", feature = "stm32f103xE", feature = "stm32f103xF", feature = "stm32f103xG"))))]
+macro_rules! memory_file {
+    () => {
+        include_bytes!("memory/stm32f103x6.x")
+    }
+}
+
+#[cfg(all(feature = "stm32f103x8", not(any(feature = "stm32f103x4", feature = "stm32f103x6", feature = "stm32f103xB", feature = "stm32f103xC", feature = "stm32f103xD", feature = "stm32f103xE", feature = "stm32f103xF", feature = "stm32f103xG"))))]
+macro_rules! memory_file {
+    () => {
+        include_bytes!("memory/stm32f103x8.x")
+    }
+}
+
+#[cfg(all(feature = "stm32f103xB", not(any(feature = "stm32f103x4", feature = "stm32f103x6", feature = "stm32f103x8", feature = "stm32f103xC", feature = "stm32f103xD", feature = "stm32f103xE", feature = "stm32f103xF", feature = "stm32f103xG"))))]
+macro_rules! memory_file {
+    () => {
+        include_bytes!("memory/stm32f103xB.x")
+    }
+}
+
+#[cfg(all(feature = "stm32f103xC", not(any(feature = "stm32f103x4", feature = "stm32f103x6", feature = "stm32f103x8", feature = "stm32f103xB", feature = "stm32f103xD", feature = "stm32f103xE", feature = "stm32f103xF", feature = "stm32f103xG"))))]
+macro_rules! memory_file {
+    () => {
+        include_bytes!("memory/stm32f103xC.x")
+    }
+}
+
+#[cfg(all(feature = "stm32f103xD", not(any(feature = "stm32f103x4", feature = "stm32f103x6", feature = "stm32f103x8", feature = "stm32f103xB", feature = "stm32f103xC", feature = "stm32f103xE", feature = "stm32f103xF", feature = "stm32f103xG"))))]
+macro_rules! memory_file {
+    () => {
+        include_bytes!("memory/stm32f103xD.x")
+    }
+}
+
+#[cfg(all(feature = "stm32f103xE", not(any(feature = "stm32f103x4", feature = "stm32f103x6", feature = "stm32f103x8", feature = "stm32f103xB", feature = "stm32f103xC", feature = "stm32f103xD", feature = "stm32f103xF", feature = "stm32f103xG"))))]
+macro_rules! memory_file {
+    () => {
+        include_bytes!("memory/stm32f103xE.x")
+    }
+}
+
+#[cfg(all(feature = "stm32f103xF", not(any(feature = "stm32f103x4", feature = "stm32f103x6", feature = "stm32f103x8", feature = "stm32f103xB", feature = "stm32f103xC", feature = "stm32f103xD", feature = "stm32f103xE", feature = "stm32f103xG"))))]
+macro_rules! memory_file {
+    () => {
+        include_bytes!("memory/stm32f103xF.x")
+    }
+}
+
+#[cfg(all(feature = "stm32f103xG", not(any(feature = "stm32f103x4", feature = "stm32f103x6", feature = "stm32f103x8", feature = "stm32f103xB", feature = "stm32f103xC", feature = "stm32f103xD", feature = "stm32f103xE", feature = "stm32f103xF"))))]
+macro_rules! memory_file {
+    () => {
+        include_bytes!("memory/stm32f103xG.x")
+    }
+}
+
 pub fn main() {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
     File::create(out.join("memory.x"))
         .unwrap()
-        .write_all(include_bytes!("memory.x"))
+        .write_all(memory_file!())
         .unwrap();
     println!("cargo:rustc-link-search={}", out.display());
 

--- a/memory/stm32f103x4.x
+++ b/memory/stm32f103x4.x
@@ -1,0 +1,6 @@
+/* Linker script for low-density flash STM32F103x4 MCUs */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 16K
+  RAM : ORIGIN = 0x20000000, LENGTH = 6K
+}

--- a/memory/stm32f103x6.x
+++ b/memory/stm32f103x6.x
@@ -1,0 +1,6 @@
+/* Linker script for low-density flash STM32F103x6 MCUs */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 32K
+  RAM : ORIGIN = 0x20000000, LENGTH = 10K
+}

--- a/memory/stm32f103x8.x
+++ b/memory/stm32f103x8.x
@@ -1,4 +1,4 @@
-/* Linker script for the STM32F103C8T6 */
+/* Linker script for medium-density flash STM32F103x8 MCUs */
 MEMORY
 {
   FLASH : ORIGIN = 0x08000000, LENGTH = 64K

--- a/memory/stm32f103xB.x
+++ b/memory/stm32f103xB.x
@@ -1,0 +1,6 @@
+/* Linker script for medium-density flash STM32F103xB MCUs */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 128K
+  RAM : ORIGIN = 0x20000000, LENGTH = 20K
+}

--- a/memory/stm32f103xC.x
+++ b/memory/stm32f103xC.x
@@ -1,0 +1,6 @@
+/* Linker script for high-density flash STM32F103xC MCUs */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 256K
+  RAM : ORIGIN = 0x20000000, LENGTH = 64K
+}

--- a/memory/stm32f103xD.x
+++ b/memory/stm32f103xD.x
@@ -1,0 +1,6 @@
+/* Linker script for high-density flash STM32F103xD MCUs */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 384K
+  RAM : ORIGIN = 0x20000000, LENGTH = 64K
+}

--- a/memory/stm32f103xE.x
+++ b/memory/stm32f103xE.x
@@ -1,0 +1,6 @@
+/* Linker script for high-density flash STM32F103xE MCUs */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 512K
+  RAM : ORIGIN = 0x20000000, LENGTH = 64K
+}

--- a/memory/stm32f103xF.x
+++ b/memory/stm32f103xF.x
@@ -1,0 +1,6 @@
+/* Linker script for XL-density flash STM32F103xF MCUs */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 768K
+  RAM : ORIGIN = 0x20000000, LENGTH = 96K
+}

--- a/memory/stm32f103xG.x
+++ b/memory/stm32f103xG.x
@@ -1,0 +1,6 @@
+/* Linker script for XL-density flash STM32F103xG MCUs */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 1M
+  RAM : ORIGIN = 0x20000000, LENGTH = 96K
+}


### PR DESCRIPTION
Stm32f103xx MCUs come in different flash densities, which affects the
FLASH and RAM specified in memory.x. This change adds features to this
board support package to be able to specify which flash density you
wish to target. This relates to, but does not directly fix, issue #37.