### PR TITLE
Apply prescaler and reset counter on timer start

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -115,8 +115,6 @@ macro_rules! hal {
                 {
                     // pause
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
-                    // restart counter
-                    self.tim.cnt.reset();
 
                     let frequency = timeout.into().0;
 
@@ -128,6 +126,13 @@ macro_rules! hal {
 
                     let arr = u16(ticks / u32(psc + 1)).unwrap();
                     self.tim.arr.write(|w| unsafe { w.bits(u32(arr)) });
+
+                    // Trigger an update event to load the prescaler value to the clock
+                    self.tim.egr.write(|w| w.ug().set_bit());
+                    // The above line raises an update event which will indicate
+                    // that the timer is already finnished. Since this is not the case,
+                    // it should be cleared
+                    self.tim.sr.modify(|_, w| w.uif().clear_bit());
 
                     // start counter
                     self.tim.cr1.modify(|_, w| w.cen().set_bit());


### PR DESCRIPTION
First of all, this commit fixes #57. Turns out that the prescaler value isn't applied until after an "update" event which gets triggered when the counter resets. This commit makes the update event trigger in the start function and then resets the `uif` flag which would otherwise indicate that the timer is already done.

This also fixes an issue where the following program would not wait for the second timer

```rust
loop {
    timer1.start(Hertz(2));
    block!(timer1.wait));
    timer2.start(Hertz(1));
    block(timer2.wait());
}
```