### PR TITLE
Fix off-by-one for maximum RCC clock rates.

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -140,7 +140,7 @@ impl CFGR {
 
         let sysclk = pllmul * HSI / 2;
 
-        assert!(sysclk < 72_000_000);
+        assert!(sysclk <= 72_000_000);
 
         let hpre_bits = self.hclk
             .map(|hclk| match sysclk / hclk {
@@ -159,7 +159,7 @@ impl CFGR {
 
         let hclk = sysclk / (1 << (hpre_bits - 0b0111));
 
-        assert!(hclk < 72_000_000);
+        assert!(hclk <= 72_000_000);
 
         let ppre1_bits = self.pclk1
             .map(|pclk1| match hclk / pclk1 {
@@ -175,7 +175,7 @@ impl CFGR {
         let ppre1 = 1 << (ppre1_bits - 0b011);
         let pclk1 = hclk / u32(ppre1);
 
-        assert!(pclk1 < 36_000_000);
+        assert!(pclk1 <= 36_000_000);
 
         let ppre2_bits = self.pclk2
             .map(|pclk2| match hclk / pclk2 {
@@ -191,7 +191,7 @@ impl CFGR {
         let ppre2 = 1 << (ppre2_bits - 0b011);
         let pclk2 = hclk / u32(ppre2);
 
-        assert!(pclk2 < 72_000_000);
+        assert!(pclk2 <= 72_000_000);
 
         // adjust flash wait states
         unsafe {


### PR DESCRIPTION
this allows setting the RCC to the maximum clock rate (72MHz)
