### PR TITLE
Make Channel a trait

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -8,7 +8,7 @@ use nb;
 use stm32f103xx::{USART1, USART2, USART3};
 
 use afio::MAPR;
-use dma::{dma1, CircBuffer, Static, Transfer, R, W};
+use dma::{dma1, CircBuffer, DmaChannel, Static, Transfer, R, W};
 use gpio::gpioa::{PA10, PA2, PA3, PA9};
 use gpio::gpiob::{PB10, PB11, PB6, PB7};
 use gpio::{Alternate, Floating, Input, PushPull};


### PR DESCRIPTION
This PR illustrates a change to the DMA Channels abstraction that makes them easier to pass around. For example, previously, it was impossible to do:

```rust
let mut dma1_channels = p.device.DMA1.split(&mut rcc.ahb);
let use1 = use_chan_later(dma1_channels.5);
let use2 = use_chan_later(dma1_channels.1);
```

because `dmaX_channels.N` had a type of `dmaX::CN`. Now the channels implement the `DmaChannel` trait, so the signature of `use_chan_later` can be:

```rust
fn use_chan_later(chan: DmaChannel) {
    // ...
}
```