### PR TITLE
Update to latest versions of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,13 @@ repository = "https://github.com/japaric/stm32f103xx-hal"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.4.3"
+cortex-m = "0.5.0"
 nb = "0.1.1"
-stm32f103xx = "0.9.0"
+stm32f103xx = "0.10.0"
+
+[dependencies.void]
+default-features = false
+version = "1.0.2"
 
 [dependencies.cast]
 default-features = false
@@ -19,7 +23,7 @@ version = "0.2.2"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.1.2"
+version = "0.2.0"
 
 [dev-dependencies]
 cortex-m-rtfm = "0.3.1"

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -124,15 +124,6 @@ macro_rules! gpio {
             }
 
             impl<MODE> OutputPin for $PXx<Output<MODE>> {
-                fn is_high(&self) -> bool {
-                    !self.is_low()
-                }
-
-                fn is_low(&self) -> bool {
-                    // NOTE(unsafe) atomic read with no side effects
-                    unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << self.i) == 0 }
-                }
-
                 fn set_high(&mut self) {
                     // NOTE(unsafe) atomic write to a stateless register
                     unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << self.i)) }
@@ -141,17 +132,6 @@ macro_rules! gpio {
                 fn set_low(&mut self) {
                     // NOTE(unsafe) atomic write to a stateless register
                     unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + self.i))) }
-                }
-            }
-
-            impl<MODE> $PXx<Output<MODE>> {
-                /// Toggles the output of the pin
-                pub fn toggle(&mut self) {
-                    if self.is_low() {
-                        self.set_high()
-                    } else {
-                        self.set_low()
-                    }
                 }
             }
 
@@ -306,15 +286,6 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> OutputPin for $PXi<Output<MODE>> {
-                    fn is_high(&self) -> bool {
-                        !self.is_low()
-                    }
-
-                    fn is_low(&self) -> bool {
-                        // NOTE(unsafe) atomic read with no side effects
-                        unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << $i) == 0 }
-                    }
-
                     fn set_high(&mut self) {
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << $i)) }
@@ -323,17 +294,6 @@ macro_rules! gpio {
                     fn set_low(&mut self) {
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + $i))) }
-                    }
-                }
-
-                impl<MODE> $PXi<Output<MODE>> {
-                    /// Toggles the output of the pin
-                    pub fn toggle(&mut self) {
-                        if self.is_low() {
-                            self.set_high()
-                        } else {
-                            self.set_low()
-                        }
                     }
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ extern crate cast;
 extern crate cortex_m;
 extern crate embedded_hal as hal;
 extern crate nb;
+extern crate void;
 pub extern crate stm32f103xx;
 
 pub mod afio;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -4,6 +4,7 @@ use cortex_m::peripheral::SYST;
 use hal::timer::{CountDown, Periodic};
 use nb;
 use stm32f103xx::{TIM2, TIM3, TIM4};
+use void::Void;
 
 use rcc::{APB1, Clocks};
 use time::Hertz;
@@ -61,7 +62,7 @@ impl CountDown for Timer<SYST> {
         self.tim.enable_counter();
     }
 
-    fn wait(&mut self) -> nb::Result<(), !> {
+    fn wait(&mut self) -> nb::Result<(), Void> {
         if self.tim.has_wrapped() {
             Ok(())
         } else {
@@ -138,7 +139,7 @@ macro_rules! hal {
                     self.tim.cr1.modify(|_, w| w.cen().set_bit());
                 }
 
-                fn wait(&mut self) -> nb::Result<(), !> {
+                fn wait(&mut self) -> nb::Result<(), Void> {
                     if self.tim.sr.read().uif().bit_is_clear() {
                         Err(nb::Error::WouldBlock)
                     } else {


### PR DESCRIPTION
This updates the crate to work with `stm32f103xx 0.10.0`, `cortex-m = "0.5.0"` and `embedded-hal = "0.2.0"`