### PR TITLE
Disable Jekyll to enable examples in Github pages

### DIFF
--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -12,6 +12,7 @@ main() {
     curl -Ls https://github.com/davisp/ghp-import/archive/master.tar.gz | \
         tar --strip-components 1 -C ghp-import -xz
 
+	touch target/$TARGET/doc/.nojekyll
     ./ghp-import/ghp_import.py target/$TARGET/doc
 
     set +x

--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -20,6 +20,6 @@ main() {
         echo OK
 }
 
-if [ $TRAVIS_BRANCH = master ]; then
+if [ $TRAVIS_BRANCH = staging ]; then
     main
 fi


### PR DESCRIPTION
By default GitHub pages use Jekyll, which ignores all files starting with an underscore (https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/). 

This both means long times till the site appears on GitHub pages (as it all has to go through Jekyll) and the examples 404 (https://japaric.github.io/stm32f103xx-hal/stm32f103xx_hal/examples/_00_hello/index.html). 

I've updated the `after_success.sh` script so it creates a file called `.nojekyll` so that Jekyll is disabled, which seems to solve the problem (https://rudihorn.github.io/stm32f103xx-hal/stm32f103xx_hal/examples/_00_hello/index.html). 

The one issue I faced was that seemingly builds are disabled for the `master` branch, but only the `master` branch can produce the GitHub pages, so I have changed this to the `staging` branch? This might not be desired.
