### PR TITLE
Fix MonoTimer when no debugger is connected

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -72,6 +72,18 @@ impl Into<KiloHertz> for MegaHertz {
     }
 }
 
+/// A token that can be passed around and guarantees
+/// that trace is enabled
+#[derive(Copy, Clone)]
+pub struct TraceEnabled {
+    _0: (),
+}
+
+pub fn enable_trace(mut dcb: DCB) -> TraceEnabled {
+    dcb.enable_trace();
+    TraceEnabled { _0: () }
+}
+
 /// A monotonic nondecreasing timer
 #[derive(Clone, Copy)]
 pub struct MonoTimer {
@@ -80,13 +92,11 @@ pub struct MonoTimer {
 
 impl MonoTimer {
     /// Creates a new `Monotonic` timer
-    pub fn new(mut dwt: DWT, mut dcb: DCB, clocks: Clocks) -> Self {
-        dcb.enable_trace();
+    pub fn new(mut dwt: DWT, _trace_enabled: TraceEnabled, clocks: Clocks) -> Self {
         dwt.enable_cycle_counter();
 
         // now the CYCCNT counter can't be stopped or resetted
         drop(dwt);
-        drop(dcb);
 
         MonoTimer {
             frequency: clocks.sysclk(),

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,7 @@
 //! Time units
 
 use cortex_m::peripheral::DWT;
+use cortex_m::peripheral::DCB;
 
 use rcc::Clocks;
 
@@ -79,7 +80,8 @@ pub struct MonoTimer {
 
 impl MonoTimer {
     /// Creates a new `Monotonic` timer
-    pub fn new(mut dwt: DWT, clocks: Clocks) -> Self {
+    pub fn new(mut dwt: DWT, mut dcb: DCB, clocks: Clocks) -> Self {
+        dcb.enable_trace();
         dwt.enable_cycle_counter();
 
         // now the CYCCNT counter can't be stopped or resetted

--- a/src/time.rs
+++ b/src/time.rs
@@ -86,6 +86,7 @@ impl MonoTimer {
 
         // now the CYCCNT counter can't be stopped or resetted
         drop(dwt);
+        drop(dcb);
 
         MonoTimer {
             frequency: clocks.sysclk(),


### PR DESCRIPTION
See issue japaric/stm32f103xx-hal/issues/76 and rust-embedded/cortex-m/pull/111.
This PR requires that the PR on cortex-m is merged first. Can someone help me with the versioning?
Should I bump the version in rust-embedded/cortex-m/pull/111 to ```0.5.7``` to be able to depend on it from here? Then this PR would also update the ```cortex-m``` dependency.

EDIT: Included in the PRs