### PR TITLE
Update for 1.30 beta/stable

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,8 +1,7 @@
 [target.thumbv7m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
-  "-C", "link-arg=-Wl,-Tlink.x",
-  "-C", "link-arg=-nostartfiles",
+  "-C", "link-arg=-Tlink.x",
 ]
 
 [build]

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ matrix:
     - env: TARGET=thumbv7m-none-eabi
       rust: nightly
       if: branch != master
-      addons:
-        apt:
-          packages:
-            - gcc-arm-none-eabi
+    - env: TARGET=thumbv7m-none-eabi
+      rust: beta
+      if: branch != master
 
 before_install: set -e
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,10 @@ repository = "https://github.com/japaric/stm32f103xx-hal"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.5.2"
+cortex-m = "0.5.7"
 nb = "0.1.1"
 stm32f103xx = "0.10.0"
-cortex-m-rt = "0.5.1"
-panic-semihosting = "0.3.0"
-panic-itm = "0.2.0"
+cortex-m-rt = "0.6.3"
 
 [dependencies.void]
 default-features = false
@@ -29,6 +27,8 @@ features = ["unproven"]
 version = "0.2.1"
 
 [dev-dependencies]
+panic-semihosting = "0.5.0"
+panic-itm = "0.4.0"
 # cortex-m-rtfm = "0.3.1"
 cortex-m-semihosting = "0.3.0"
 enc28j60 = "0.2.0"

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -6,7 +6,6 @@
 #![no_main]
 
 extern crate cortex_m;
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
 extern crate stm32f103xx_hal as hal;
@@ -16,10 +15,9 @@ extern crate nb;
 use hal::prelude::*;
 use hal::stm32f103xx;
 use hal::timer::Timer;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let cp = cortex_m::Peripherals::take().unwrap();
     let dp = stm32f103xx::Peripherals::take().unwrap();
@@ -47,14 +45,12 @@ fn main() -> ! {
     }
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/delay.rs
+++ b/examples/delay.rs
@@ -6,7 +6,6 @@
 #![no_std]
 
 extern crate cortex_m;
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
 extern crate stm32f103xx_hal as hal;
@@ -14,10 +13,9 @@ extern crate stm32f103xx_hal as hal;
 use hal::delay::Delay;
 use hal::prelude::*;
 use hal::stm32f103xx;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let dp = stm32f103xx::Peripherals::take().unwrap();
     let cp = cortex_m::Peripherals::take().unwrap();
@@ -40,14 +38,12 @@ fn main() -> ! {
     }
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/enc28j60-coap.rs
+++ b/examples/enc28j60-coap.rs
@@ -18,7 +18,6 @@
 
 #[macro_use]
 extern crate cortex_m;
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate enc28j60;
 extern crate heapless;
@@ -39,7 +38,7 @@ use hal::stm32f103xx;
 use heapless::consts::*;
 use heapless::FnvIndexMap;
 use jnet::{arp, coap, ether, icmp, ipv4, mac, udp, Buffer};
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
 /* Constants */
 const KB: u16 = 1024;
@@ -59,8 +58,7 @@ struct Led {
     led: bool,
 }
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let mut cp = cortex_m::Peripherals::take().unwrap();
     let dp = stm32f103xx::Peripherals::take().unwrap();
@@ -316,14 +314,12 @@ fn main() -> ! {
     }
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/enc28j60.rs
+++ b/examples/enc28j60.rs
@@ -19,7 +19,6 @@
 #![no_std]
 #![no_main]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 #[macro_use]
 extern crate cortex_m;
@@ -37,7 +36,7 @@ use hal::stm32f103xx;
 use heapless::consts::*;
 use heapless::FnvIndexMap;
 use jnet::{arp, ether, icmp, ipv4, mac, udp, Buffer};
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
 // uncomment to disable tracing
 // macro_rules! iprintln {
@@ -51,8 +50,7 @@ const IP: ipv4::Addr = ipv4::Addr([192, 168, 1, 33]);
 /* Constants */
 const KB: u16 = 1024; // bytes
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let mut cp = cortex_m::Peripherals::take().unwrap();
     let dp = stm32f103xx::Peripherals::take().unwrap();
@@ -273,14 +271,12 @@ fn main() -> ! {
     }
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,35 +5,17 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate cortex_m_semihosting as sh;
 extern crate panic_semihosting;
 extern crate stm32f103xx_hal;
 
 use core::fmt::Write;
+use rt::entry;
 
-use rt::ExceptionFrame;
-use sh::hio;
-
-entry!(main);
-
+#[entry]
 fn main() -> ! {
-    let mut hstdout = hio::hstdout().unwrap();
-
+    let mut hstdout = sh::hio::hstdout().unwrap();
     writeln!(hstdout, "Hello, world!").unwrap();
-
     loop {}
-}
-
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
-}
-
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
-    panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/itm.rs
+++ b/examples/itm.rs
@@ -3,17 +3,15 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 #[macro_use]
 extern crate cortex_m;
 extern crate panic_itm;
 extern crate stm32f103xx_hal;
 
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let p = cortex_m::Peripherals::take().unwrap();
     let mut itm = p.ITM;
@@ -23,14 +21,12 @@ fn main() -> ! {
     loop {}
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -5,17 +5,15 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
 extern crate stm32f103xx_hal as hal;
 
 use hal::prelude::*;
 use hal::stm32f103xx;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let p = stm32f103xx::Peripherals::take().unwrap();
 
@@ -27,14 +25,12 @@ fn main() -> ! {
     loop {}
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/mfrc522.rs
+++ b/examples/mfrc522.rs
@@ -5,7 +5,6 @@
 
 #[macro_use]
 extern crate cortex_m;
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate mfrc522;
 extern crate panic_itm;
@@ -15,10 +14,9 @@ use hal::prelude::*;
 use hal::spi::Spi;
 use hal::stm32f103xx;
 use mfrc522::Mfrc522;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let mut cp = cortex_m::Peripherals::take().unwrap();
     let dp = stm32f103xx::Peripherals::take().unwrap();
@@ -60,14 +58,12 @@ fn main() -> ! {
     }
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/motor.rs
+++ b/examples/motor.rs
@@ -5,7 +5,6 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate cortex_m_semihosting as sh;
 extern crate motor_driver;
@@ -21,10 +20,9 @@ use hal::serial::Serial;
 use hal::stm32f103xx;
 use motor_driver::Motor;
 use sh::hio;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let p = stm32f103xx::Peripherals::take().unwrap();
 
@@ -104,14 +102,12 @@ fn main() -> ! {
     }
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/mpu9250.rs
+++ b/examples/mpu9250.rs
@@ -5,7 +5,6 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate cortex_m;
 extern crate mpu9250;
@@ -18,10 +17,9 @@ use hal::prelude::*;
 use hal::spi::Spi;
 use hal::stm32f103xx;
 use mpu9250::Mpu9250;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let cp = cortex_m::Peripherals::take().unwrap();
     let dp = stm32f103xx::Peripherals::take().unwrap();
@@ -73,14 +71,12 @@ fn main() -> ! {
     loop {}
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -5,7 +5,6 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate cortex_m;
 extern crate panic_semihosting;
@@ -14,10 +13,9 @@ extern crate stm32f103xx_hal as hal;
 use cortex_m::asm;
 use hal::prelude::*;
 use hal::stm32f103xx;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let p = stm32f103xx::Peripherals::take().unwrap();
 
@@ -81,14 +79,12 @@ fn main() -> ! {
     loop {}
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/qei.rs
+++ b/examples/qei.rs
@@ -5,7 +5,6 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate cortex_m;
 extern crate cortex_m_semihosting as semihosting;
@@ -18,11 +17,10 @@ use hal::delay::Delay;
 use hal::prelude::*;
 use hal::qei::Qei;
 use hal::stm32f103xx;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 use semihosting::hio;
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let dp = stm32f103xx::Peripherals::take().unwrap();
     let cp = cortex_m::Peripherals::take().unwrap();
@@ -64,14 +62,12 @@ fn main() -> ! {
     }
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/serial-dma-circ.rs
+++ b/examples/serial-dma-circ.rs
@@ -5,7 +5,6 @@
 #![no_std]
 #![no_main]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 #[macro_use(singleton)]
 extern crate cortex_m;
@@ -17,11 +16,9 @@ use hal::dma::Half;
 use hal::prelude::*;
 use hal::serial::Serial;
 use hal::stm32f103xx;
+use rt::{entry, exception, ExceptionFrame};
 
-use rt::ExceptionFrame;
-
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let p = stm32f103xx::Peripherals::take().unwrap();
 
@@ -79,14 +76,12 @@ fn main() -> ! {
     loop {}
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/serial-dma-peek.rs
+++ b/examples/serial-dma-peek.rs
@@ -5,7 +5,6 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 #[macro_use(singleton)]
 extern crate cortex_m;
@@ -16,10 +15,9 @@ use cortex_m::asm;
 use hal::prelude::*;
 use hal::serial::Serial;
 use hal::stm32f103xx;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let p = stm32f103xx::Peripherals::take().unwrap();
 
@@ -75,14 +73,12 @@ fn main() -> ! {
     loop {}
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/serial-dma-rx.rs
+++ b/examples/serial-dma-rx.rs
@@ -5,7 +5,6 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 #[macro_use(singleton)]
 extern crate cortex_m;
@@ -16,11 +15,9 @@ use cortex_m::asm;
 use hal::prelude::*;
 use hal::serial::Serial;
 use hal::stm32f103xx;
+use rt::{entry, exception, ExceptionFrame};
 
-use rt::ExceptionFrame;
-
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let p = stm32f103xx::Peripherals::take().unwrap();
 
@@ -70,14 +67,12 @@ fn main() -> ! {
     loop {}
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/serial-dma-tx.rs
+++ b/examples/serial-dma-tx.rs
@@ -5,7 +5,6 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate cortex_m;
 extern crate panic_semihosting;
@@ -15,11 +14,9 @@ use cortex_m::asm;
 use hal::prelude::*;
 use hal::serial::Serial;
 use hal::stm32f103xx;
+use rt::{entry, exception, ExceptionFrame};
 
-use rt::ExceptionFrame;
-
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let p = stm32f103xx::Peripherals::take().unwrap();
 
@@ -76,14 +73,12 @@ fn main() -> ! {
     loop {}
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -7,7 +7,6 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
 extern crate cortex_m_rt as rt;
 extern crate cortex_m;
 #[macro_use(block)]
@@ -19,10 +18,9 @@ use cortex_m::asm;
 use hal::prelude::*;
 use hal::serial::Serial;
 use hal::stm32f103xx;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let p = stm32f103xx::Peripherals::take().unwrap();
 
@@ -76,14 +74,12 @@ fn main() -> ! {
     loop {}
 }
 
-exception!(HardFault, hard_fault);
-
-fn hard_fault(ef: &ExceptionFrame) -> ! {
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }
 
-exception!(*, default_handler);
-
-fn default_handler(irqn: i16) {
+#[exception]
+fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -127,7 +127,6 @@ macro_rules! dma {
     }),)+) => {
         $(
             pub mod $dmaX {
-                use core::marker::Unsize;
                 use core::sync::atomic::{self, Ordering};
 
                 use stm32f103xx::{$DMAX, dma1};
@@ -287,11 +286,11 @@ macro_rules! dma {
                     impl<BUFFER, PAYLOAD> Transfer<W, &'static mut BUFFER, $CX, PAYLOAD> {
                         pub fn peek<T>(&self) -> &[T]
                         where
-                            BUFFER: Unsize<[T]>,
+                            BUFFER: AsRef<[T]>,
                         {
                             let pending = self.channel.get_cndtr() as usize;
 
-                            let slice: &[T] = self.buffer;
+                            let slice = self.buffer.as_ref();
                             let capacity = slice.len();
 
                             &slice[..(capacity - pending)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@
 //!
 //! [examples]: examples/index.html
 
-#![feature(unsize)]
 #![no_std]
 
 extern crate cast;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@
 //! [examples]: examples/index.html
 
 #![feature(unsize)]
-#![feature(never_type)]
 #![no_std]
 
 extern crate cast;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -6,6 +6,7 @@ use cast::u16;
 use hal;
 use nb;
 use stm32f103xx::{USART1, USART2, USART3};
+use void::Void;
 
 use afio::MAPR;
 use dma::{dma1, CircBuffer, Static, Transfer, R, W};
@@ -353,9 +354,9 @@ macro_rules! hal {
             }
 
             impl hal::serial::Write<u8> for Tx<$USARTX> {
-                type Error = !;
+                type Error = Void;
 
-                fn flush(&mut self) -> nb::Result<(), !> {
+                fn flush(&mut self) -> nb::Result<(), Self::Error> {
                     // NOTE(unsafe) atomic read with no side effects
                     let sr = unsafe { (*$USARTX::ptr()).sr.read() };
 
@@ -366,7 +367,7 @@ macro_rules! hal {
                     }
                 }
 
-                fn write(&mut self, byte: u8) -> nb::Result<(), !> {
+                fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
                     // NOTE(unsafe) atomic read with no side effects
                     let sr = unsafe { (*$USARTX::ptr()).sr.read() };
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,4 +1,4 @@
-use core::marker::{PhantomData, Unsize};
+use core::marker::PhantomData;
 use core::ptr;
 use core::sync::atomic::{self, Ordering};
 
@@ -205,10 +205,10 @@ macro_rules! hal {
                     buffer: &'static mut [B; 2],
                 ) -> CircBuffer<B, $rx_chan>
                 where
-                    B: Unsize<[u8]>,
+                    B: AsMut<[u8]>,
                 {
                     {
-                        let buffer: &[u8] = &buffer[0];
+                        let buffer = buffer[0].as_mut();
                         chan.cmar().write(|w| unsafe {
                             w.ma().bits(buffer.as_ptr() as usize as u32)
                         });
@@ -255,10 +255,10 @@ macro_rules! hal {
                     buffer: &'static mut B,
                 ) -> Transfer<W, &'static mut B, $rx_chan, Self>
                 where
-                    B: Unsize<[u8]>,
+                    B: AsMut<[u8]>,
                 {
                     {
-                        let buffer: &[u8] = buffer;
+                        let buffer = buffer.as_mut();
                         chan.cmar().write(|w| unsafe {
                             w.ma().bits(buffer.as_ptr() as usize as u32)
                         });
@@ -307,11 +307,11 @@ macro_rules! hal {
                     buffer: B,
                 ) -> Transfer<R, B, $tx_chan, Self>
                 where
-                    A: Unsize<[u8]>,
+                    A: AsRef<[u8]>,
                     B: Static<A>,
                 {
                     {
-                        let buffer: &[u8] = buffer.borrow();
+                        let buffer = buffer.borrow().as_ref();
                         chan.cmar().write(|w| unsafe {
                             w.ma().bits(buffer.as_ptr() as usize as u32)
                         });


### PR DESCRIPTION
This PR make stm32f103xx-hal compile on the 1.30 beta (and hopefully 1.30 stable).

There is 3 changes:
 - upgrade cortex-m-rt and panic-*
 - remove the never_type feature by using the void crate
 - remove the unsize feature by using the AsMut trait

Removing the unsize feature might decrease a bit the ergonomics. Now, if you want a buffer bigger that 32, you'll have to define a new type like that:

```rust
struct MyBuf([u8; 256]);
impl AsMut<[u8]> for MyBuf {
    fn as_mut(&mut self) -> &mut [u8] {
        &mut self.0
    }
}
```

@japaric OK?