### PR TITLE
Fixed invalid RVR value when creating a delay

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -48,7 +48,7 @@ impl DelayMs<u8> for Delay {
 impl DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
         // The RVR register is 24 bits wide, as SysTick is based on a 24 bit counter
-        const MAX_RVR: u32 = (1 << 24);
+        const MAX_RVR: u32 = (1 << 24) - 1;
 
         let mut total_rvr = us * (self.clocks.sysclk().0 / 1_000_000);
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -47,13 +47,13 @@ impl DelayMs<u8> for Delay {
 
 impl DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
-        // The RVR register is 24 bits wide, as SysTick is based on a 24 bit counter
-        const MAX_RVR: u32 = (1 << 24) - 1;
+        // The SysTick Reload Value register supports values between 1 and 0x00FFFFFF.
+        const MAX_RVR: u32 =  0x00FF_FFFF;
 
         let mut total_rvr = us * (self.clocks.sysclk().0 / 1_000_000);
 
         while total_rvr != 0 {
-            let current_rvr = if total_rvr < MAX_RVR {
+            let current_rvr = if total_rvr <= MAX_RVR {
                 total_rvr
             } else {
                 MAX_RVR


### PR DESCRIPTION
This fix originates from this [discussion](https://github.com/therealprof/stm32f4xx-hal/pull/6).
Thanks @jamesmunns