### PR TITLE
Update usage instructions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@
 //!
 //! - Building an application (binary crate)
 //!
-//! Follow the [cortex-m-quickstart] instructions and add this crate as a dependency in step number
-//! 5 and make sure you enable the "rt" Cargo feature of this crate.
+//! Follow the [cortex-m-quickstart] instructions and add this crate as a dependency
+//! and make sure you enable the "rt" Cargo feature of this crate.
 //!
 //! [cortex-m-quickstart]: https://docs.rs/cortex-m-quickstart/~0.2.3
 //!


### PR DESCRIPTION
Remove reference to "step 5" of the cortex-m-quickstart instructions, as that step was removed from the instructions.
(In the linked instructions at https://docs.rs/cortex-m-quickstart/~0.2.3 it's still present as step 6, but the current git version at https://github.com/rust-embedded/cortex-m-quickstart doesn't contain that step at all.)