### PR TITLE
Add function for disabling JTAG

### DIFF
--- a/examples/nojtag.rs
+++ b/examples/nojtag.rs
@@ -16,12 +16,10 @@ use rt::{entry, exception, ExceptionFrame};
 #[entry]
 fn main() -> ! {
     let p = stm32f103xx::Peripherals::take().unwrap();
-    // let cp = stm32f103xx::CorePeripherals::take().unwrap();
 
     let mut rcc = p.RCC.constrain();
     let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
     let mut afio = p.AFIO.constrain(&mut rcc.apb2);
-
 
     afio.mapr.disable_jtag();
 

--- a/examples/nojtag.rs
+++ b/examples/nojtag.rs
@@ -1,0 +1,41 @@
+//! Disables the JTAG ports to give access to pb3, pb4 and PA15
+
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+extern crate cortex_m_rt as rt;
+extern crate panic_semihosting;
+extern crate stm32f103xx_hal as hal;
+
+use hal::prelude::*;
+use hal::stm32f103xx;
+use rt::{entry, exception, ExceptionFrame};
+
+#[entry]
+fn main() -> ! {
+    let p = stm32f103xx::Peripherals::take().unwrap();
+    // let cp = stm32f103xx::CorePeripherals::take().unwrap();
+
+    let mut rcc = p.RCC.constrain();
+    let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+    let mut afio = p.AFIO.constrain(&mut rcc.apb2);
+
+
+    afio.mapr.disable_jtag();
+
+    gpiob.pb4.into_push_pull_output(&mut gpiob.crl).set_low();
+
+    loop {}
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}
+
+#[exception]
+fn DefaultHandler(irqn: i16) {
+    panic!("Unhandled exception (IRQn = {})", irqn);
+}

--- a/src/afio.rs
+++ b/src/afio.rs
@@ -53,9 +53,7 @@ impl MAPR {
         unsafe { &(*AFIO::ptr()).mapr }
     }
 
-    /**
-      Disables the JTAG to free up pb3, pb4 and pa15 for normal use
-    */
+    /// Disables the JTAG to free up pb3, pb4 and pa15 for normal use
     pub fn disable_jtag(&mut self) {
         self.mapr().modify(|_, w| unsafe{w.swj_cfg().bits(0b010)})
     }

--- a/src/afio.rs
+++ b/src/afio.rs
@@ -52,6 +52,13 @@ impl MAPR {
     pub fn mapr(&mut self) -> &afio::MAPR {
         unsafe { &(*AFIO::ptr()).mapr }
     }
+
+    /**
+      Disables the JTAG to free up pb3, pb4 and pa15 for normal use
+    */
+    pub fn disable_jtag(&mut self) {
+        self.mapr().modify(|_, w| unsafe{w.swj_cfg().bits(0b010)})
+    }
 }
 
 pub struct EXTICR1 {


### PR DESCRIPTION
This adds a function for disabling the JTAG device in order to free up pb3, pb4 and pa15 as mentioned in #116 