### PR TITLE
[I2C] Allow read-/write-only transactions in write_read

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -455,13 +455,15 @@ macro_rules! hal {
                     bytes: &[u8],
                     buffer: &mut [u8],
                 ) -> Result<(), Self::Error> {
-                    assert!(buffer.len() > 0);
-
-                    if bytes.len() != 0 {
+                    if !bytes.is_empty() {
                         self.write_without_stop(addr, bytes)?;
                     }
 
-                    self.read(addr, buffer)?;
+                    if !buffer.is_empty() {
+                        self.read(addr, buffer)?;
+                    } else if !bytes.is_empty() {
+                        self.nb.send_stop();
+                    }
 
                     Ok(())
                 }


### PR DESCRIPTION
For WriteRead::write_read only:

Allow transactions, with only read or write requests. More importantly, don't panic anymore (there is no mention of a valid panic at https://github.com/rust-embedded/embedded-hal/blob/master/src/blocking/i2c.rs#L75). Also use ```.is_empty()``` instead of ```== 0```