### PR TITLE
add warning about timer interrupts.

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -34,6 +34,8 @@ impl Timer<SYST> {
     }
 
     /// Starts listening for an `event`
+    /// You *have* to call `wait()` from your event handler to clear the interrupt flag (UIF),
+    /// otherwise the interrupt handler will execute continuously.
     pub fn listen(&mut self, event: Event) {
         match event {
             Event::Update => self.tim.enable_interrupt(),


### PR DESCRIPTION
I added a warning in the documentation about the need to clear interrupt flags on timer interrupt. I spent quite some time finding why I didn't get my requested frequency.