### PR TITLE
Add predivided clock speeds

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -208,7 +208,7 @@ macro_rules! hal {
                         .modify(|_, w| w.oc4pe().set_bit().oc4m().pwm1());
                 }
 
-                let clk = clocks.pclk1().0 * if clocks.ppre1() == 1 { 1 } else { 2 };
+                let clk = clocks.pclk1_tim().0;
                 let freq = freq.0;
                 let ticks = clk / freq;
                 let psc = u16(ticks / (1 << 16)).unwrap();

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -318,9 +318,19 @@ impl Clocks {
         self.pclk1
     }
 
+    /// Returns the frequency of the APB1 Timers
+    pub fn pclk1_tim(&self) -> Hertz {
+        Hertz(self.pclk1.0 * if self.ppre1() == 1 { 1 } else { 2 })
+    }
+
     /// Returns the frequency of the APB2
     pub fn pclk2(&self) -> Hertz {
         self.pclk2
+    }
+
+    /// Returns the frequency of the APB2 Timers
+    pub fn pclk2_tim(&self) -> Hertz {
+        Hertz(self.pclk2.0 * if self.ppre2() == 1 { 1 } else { 2 })
     }
 
     pub(crate) fn ppre1(&self) -> u8 {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -34,6 +34,8 @@ impl Timer<SYST> {
     }
 
     /// Starts listening for an `event`
+    /// You *have* to call `wait()` from your event handler to clear the interrupt flag (UIF),
+    /// otherwise the interrupt handler will execute continuously.
     pub fn listen(&mut self, event: Event) {
         match event {
             Event::Update => self.tim.enable_interrupt(),

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -113,28 +113,9 @@ macro_rules! hal {
                 /// Return the bus clock frequency in hertz.
                 fn get_bus_clock(&self) -> Hertz {
                     if TypeId::of::<$apbX>() == TypeId::of::<APB1>() {
-                            Hertz(self.clocks.pclk1().0 * self.get_bus_frequency_multiplier())
+                        self.clocks.pclk1_tim()
                     } else if TypeId::of::<$apbX>() == TypeId::of::<APB2>() {
-                        Hertz(self.clocks.pclk2().0 * self.get_bus_frequency_multiplier())
-                    } else {
-                        unreachable!()
-                    }
-                }
-
-                /// Return the bus frequency multiplier.
-                fn get_bus_frequency_multiplier(&self) -> u32 {
-                    if TypeId::of::<$apbX>() == TypeId::of::<APB1>() {
-                        if self.clocks.ppre1() == 1 {
-                            1
-                        } else {
-                            2
-                        }
-                    } else if TypeId::of::<$apbX>() == TypeId::of::<APB2>() {
-                         if self.clocks.ppre2() == 1 {
-                            1
-                         } else {
-                            2
-                         }
+                        self.clocks.pclk2_tim()
                     } else {
                         unreachable!()
                     }


### PR DESCRIPTION
This PR centralises the bus clock division code for timers in the Clock struct.
The same thing might be useful for ADCs when they land.